### PR TITLE
Add support for client certificate authentication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 2025-01-17
+
+### Added
+
+- A `railnova_kafka_mtls.py` program to access the Kafka broker using mTLS instead of SASL.
+
+### Changed
+
+- The program `railnova_kafka_example.py`'s help now specify its use of SASL.
+- The `README.md` has been updated to reflect changes above.
+
 ## 2025-01-14
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - A `railnova_kafka_mtls.py` program to access the Kafka broker using mTLS instead of SASL.
+- A `railnova_kafka_nosr.py` program to access the Kafka broker using mTLS without Schema Registry.
+- All the AVRO schemas required for Railnova's output sharing topics in a `schemas` folder.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ python railnova_kafka_example.py --hostname=kafka-prod-railnova-5ffc.aivencloud.
 By default, this programm will use `railnova_kafka_example` as its [consumer's group identifier](https://www.confluent.io/blog/configuring-apache-kafka-consumer-group-ids/). If you need to provide another, use the `--group-id` argument.
 
 
-## Run - SSL access key and certificate authentication
+## Run - mTLS Authentication
 
 Another example Python program called `railnova_kafka_mtls.py` uses SSL client key
 and certificate to connect to Railnova's Kafka broker and fetch a single message from a topic.
@@ -86,6 +86,36 @@ You should see the following log output:
 2025-01-17 09:29:28,052 INFO Kafka consumer subscribed to topic 'output-sharing-******'
 2025-01-17 09:29:35,407 INFO Received {'type': 'A', 'id': 10752} -> {'type': 'analog', 'timestamp': '2025-01-14T11:14:04Z', 'asset': 10752, 'device': 4006, 'asset_uic': None, 'is_open': True, 'content': '{"fuel_gauge_volt": 0.006280615626568774, "main_battery": 26.696541797683896, "main_battery_volt": 26.696541797683896, "support_battery": 25.100480351582107, "support_battery_volt": 25.100480351582107}', 'version': None, 'recv_time': '2025-01-14T11:14:06Z', 'processed_time': '2025-01-14 11:14:06', 'source': 'railster-pipe', 'header': {'nohistory': None, 'nomerge': None, 'job': None, 'nonotifications': None}}
 ```
+
+## Run - mTLS Authentication and no Schema Registry
+
+If you do not want to distribute user name and password, there is a third example Python program 
+called `railnova_kafka_nosr.py` that uses SSL client key and certificate to connect to Railnova's
+Kafka broker but which does not depend on the Kafka Schema Registry to decode AVRO payloads.
+
+```bash
+python railnova_kafka_nosr.py --topic=... --key=... --certificate=...
+```
+
+As above the `--key` and `--certificate` arguments are respectively the locations to the `service.key`
+and `service.cert` files supplied separately. But since it does not depend on the Schema Registry, 
+user name and password are not required.
+
+You should see the following log output:
+
+```log
+2025-01-17 10:07:37,158 INFO Kafka consumer subscribed to topic 'output-sharing-******'
+2025-01-17 10:07:43,207 INFO Received {'type': 'A', 'id': 10752} -> {'type': 'telematic', 'timestamp': '2025-01-14T11:14:17Z', 'asset': 10752, 'device': 4006, 'asset_uic': None, 'is_open': True, 'content': '{"decoded_as": "bb75000", "state": 2, "status": "parking", "status_last_change": "2025-01-14T09:08:29Z"}', 'version': None, 'recv_time': '2025-01-14T11:14:18Z', 'processed_time': '2025-01-14 11:14:19', 'source': None, 'header': {'nohistory': None, 'nomerge': None, 'job': None, 'nonotifications': None}}
+```
+
+If an unknown schema is used in the topic consumed, the exception below will be raised:
+
+```
+ValueError: Unknown schema id: ...
+```
+
+Make sure to update to the latest version of this repository to have all the schemas in use by Railnova.
+
 
 ## Troubleshoot
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ This will install version `2.8.0` of Confluent's client library with the optiona
 and Kafka Schema Registry along with all their dependencies.
 
 
-## Run
+## Run - SASL Authentication
 
 The example Python program called `railnova_kafka_example.py` requires three arguments
 to connect to Railnova's Kafka broker and fetch a single message from a topic.
@@ -64,6 +64,28 @@ python railnova_kafka_example.py --hostname=kafka-prod-railnova-5ffc.aivencloud.
 
 By default, this programm will use `railnova_kafka_example` as its [consumer's group identifier](https://www.confluent.io/blog/configuring-apache-kafka-consumer-group-ids/). If you need to provide another, use the `--group-id` argument.
 
+
+## Run - SSL access key and certificate authentication
+
+Another example Python program called `railnova_kafka_mtls.py` uses SSL client key
+and certificate to connect to Railnova's Kafka broker and fetch a single message from a topic.
+
+```bash
+python railnova_kafka_mtls.py --username=... --password=... --topic=... --key=... --certificate=...
+```
+
+The `--key` and `--certificate` arguments are respectively the locations to the `service.key`
+and `service.cert` files supplied separately.
+
+Note that a user name and a password are still required, but only to connect to the Kafka Schema Registry.
+
+You should see the following log output:
+
+```log
+2025-01-17 09:29:28,049 INFO Schema registry is accessible at 'kafka-13e7abdf-test-railnova-5ffc.aivencloud.com'
+2025-01-17 09:29:28,052 INFO Kafka consumer subscribed to topic 'output-sharing-******'
+2025-01-17 09:29:35,407 INFO Received {'type': 'A', 'id': 10752} -> {'type': 'analog', 'timestamp': '2025-01-14T11:14:04Z', 'asset': 10752, 'device': 4006, 'asset_uic': None, 'is_open': True, 'content': '{"fuel_gauge_volt": 0.006280615626568774, "main_battery": 26.696541797683896, "main_battery_volt": 26.696541797683896, "support_battery": 25.100480351582107, "support_battery_volt": 25.100480351582107}', 'version': None, 'recv_time': '2025-01-14T11:14:06Z', 'processed_time': '2025-01-14 11:14:06', 'source': 'railster-pipe', 'header': {'nohistory': None, 'nomerge': None, 'job': None, 'nonotifications': None}}
+```
 
 ## Troubleshoot
 

--- a/railnova_kafka_mtls.py
+++ b/railnova_kafka_mtls.py
@@ -14,18 +14,26 @@ SSL_CA_LOCATION = os.path.abspath(os.path.join(os.path.dirname(__file__), "ca.pe
 class Arguments(argparse.Namespace):
     username: str
     password: str
+    cert_path: str
+    key_path: str
     topic: str
     hostname: str
     group_id: str
 
 
 def arguments() -> Arguments:
-    parser = argparse.ArgumentParser(description="Railnova Kafka Avro consumer example with SASL")
+    parser = argparse.ArgumentParser(description="Railnova Kafka Avro consumer example with mTLS")
     parser.add_argument(
         "--username", dest="username", required=True, help="SASL username"
     )
     parser.add_argument(
         "--password", dest="password", required=True, help="SASL password"
+    )
+    parser.add_argument(
+        "--certificate", dest="cert_path", required=True, help="Path to the Access Certificate file"
+    )
+    parser.add_argument(
+        "--key", dest="key_path", required=True, help="Path to the Access Key file"
     )
     parser.add_argument("--topic", dest="topic", required=True, help="Kafka topic name")
     parser.add_argument(
@@ -69,12 +77,11 @@ def main() -> int:
     # Create a Kafka consumer with a sensible configuration a for a single consumer.
     kafka_consumer = Consumer(
         {
-            "security.protocol": "SASL_SSL",
-            "sasl.mechanisms": "SCRAM-SHA-256",
-            "sasl.username": args.username,
-            "sasl.password": args.password,
+            "security.protocol": "SSL",
             "ssl.ca.location": SSL_CA_LOCATION,
-            "bootstrap.servers": f"{args.hostname}:27257",
+            "ssl.certificate.location": args.cert_path,
+            "ssl.key.location": args.key_path,
+            "bootstrap.servers": f"{args.hostname}:27246",
             "message.max.bytes": 5000000,
             "group.id": args.group_id,
             "enable.auto.commit": True,  # commit the offset automatically.

--- a/railnova_kafka_nosr.py
+++ b/railnova_kafka_nosr.py
@@ -1,0 +1,141 @@
+import argparse
+import io
+import json
+import logging
+import glob
+import os
+import struct
+import sys
+
+from confluent_kafka import Consumer, KafkaError
+from fastavro.types import Schema
+from fastavro import parse_schema, schemaless_reader
+
+# Parse all schemas from the `schemas` folder and index them in a dictionary by their id.
+SCHEMAS_LOCATION = os.path.join(os.path.dirname(__file__), "schemas")
+SCHEMAS: dict[int, Schema] = {
+    int(os.path.basename(f).split(".")[0]): parse_schema(json.loads(open(f).read()))
+    for f in glob.glob(os.path.join(SCHEMAS_LOCATION, "*.json"))
+}
+
+
+def decode_avro(payload: bytes) -> dict:
+    """
+    A function to decode an Avro payload without depending on the Schema Registry
+    using instead the schemas supplied.
+    """
+    f = io.BytesIO(payload)
+    try:
+        # Read the magic byte and the schema id from the payload.
+        magic, schema_id = struct.unpack(">bI", f.read(5))
+        if schema_id not in SCHEMAS:
+            raise ValueError(f"Unknown schema id: {schema_id}")
+
+        # Decode the payload using the schema found and return the decoded result.
+        return schemaless_reader(f, SCHEMAS[schema_id])
+
+    finally:
+        f.close()
+
+
+SSL_CA_LOCATION = os.path.abspath(os.path.join(os.path.dirname(__file__), "ca.pem"))
+
+
+class Arguments(argparse.Namespace):
+    cert_path: str
+    key_path: str
+    topic: str
+    hostname: str
+    group_id: str
+
+
+def arguments() -> Arguments:
+    parser = argparse.ArgumentParser(
+        description="Railnova Kafka schema-less Avro consumer example with mTLS"
+    )
+    parser.add_argument(
+        "--certificate",
+        dest="cert_path",
+        required=True,
+        help="Path to the Access Certificate file",
+    )
+    parser.add_argument(
+        "--key", dest="key_path", required=True, help="Path to the Access Key file"
+    )
+    parser.add_argument("--topic", dest="topic", required=True, help="Kafka topic name")
+    parser.add_argument(
+        "--hostname",
+        dest="hostname",
+        default="kafka-13e7abdf-test-railnova-5ffc.aivencloud.com",
+        help="Kafka broker hostname, defaults to Railnova's test broker",
+    )
+    parser.add_argument(
+        "--group-id",
+        dest="group_id",
+        default="railnova_kafka_example",
+        help="Kafka consumer group id",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    # Parse command line arguments and configure a logger
+    args = arguments()
+    logHandler = logging.StreamHandler()
+    logHandler.setFormatter(logging.Formatter("%(asctime)s %(levelname)s %(message)s"))
+    logger = logging.getLogger("railnova_kafka_example")
+    logger.addHandler(logHandler)
+    logger.setLevel(logging.INFO)
+
+    # Create a Kafka consumer with a sensible configuration a for a single consumer.
+    kafka_consumer = Consumer(
+        {
+            "security.protocol": "SSL",
+            "ssl.ca.location": SSL_CA_LOCATION,
+            "ssl.certificate.location": args.cert_path,
+            "ssl.key.location": args.key_path,
+            "bootstrap.servers": f"{args.hostname}:27246",
+            "message.max.bytes": 5000000,
+            "group.id": args.group_id,
+            "enable.auto.commit": True,  # commit the offset automatically.
+            "auto.offset.reset": "earliest",  # start from the beginning of the topic (for this consumer group).
+            "partition.assignment.strategy": "roundrobin",  # consume from all partitions in a round-robin fashion.
+        },
+        logger=logger,
+    )
+    # see https://docs.confluent.io/platform/current/clients/confluent-kafka-python/html/index.html#pythonclient-configuration
+    #
+    # Subscribe to the given topic
+    kafka_consumer.subscribe([args.topic])
+    #
+    logger.info(f"Kafka consumer subscribed to topic '{args.topic}'")
+
+    # poll for messages until one is consumed or a keyboard SIGINT is received ...
+    while True:
+        try:
+            # SIGINT can't be handled when polling, limit timeout to 1 second.
+            message = kafka_consumer.poll(1.0)
+            if message is None:
+                continue
+
+            # Check for Kafka errors, as Confluent bundle them as messages.
+            error: KafkaError | None = message.error()
+            if error is None:
+                # log the deserialized message's key and value
+                k = decode_avro(message.key())
+                v = decode_avro(message.value())
+                logger.info(f"Received {k} -> {v}")
+                break
+
+            else:
+                # Print the error message found in the message's value
+                logger.error(bytes.decode(message.value()))
+        except KeyboardInterrupt:
+            break
+
+    kafka_consumer.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/schemas/2.json
+++ b/schemas/2.json
@@ -1,0 +1,15 @@
+{
+  "fields": [
+    {
+      "name": "type",
+      "type": "string"
+    },
+    {
+      "name": "id",
+      "type": "int"
+    }
+  ],
+  "name": "AnalystKey",
+  "namespace": "eu.railnova.supernova.analyst",
+  "type": "record"
+}

--- a/schemas/4.json
+++ b/schemas/4.json
@@ -1,0 +1,108 @@
+{
+    "fields": [
+      {
+        "name": "type",
+        "type": "string"
+      },
+      {
+        "name": "timestamp",
+        "type": "string"
+      },
+      {
+        "name": "asset",
+        "type": [
+          "int",
+          "null"
+        ]
+      },
+      {
+        "name": "device",
+        "type": [
+          "int",
+          "null"
+        ]
+      },
+      {
+        "name": "is_open",
+        "type": "boolean"
+      },
+      {
+        "name": "content",
+        "type": "string"
+      },
+      {
+        "name": "version",
+        "type": [
+          "int",
+          "null"
+        ]
+      },
+      {
+        "name": "recv_time",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      {
+        "default": null,
+        "name": "processed_time",
+        "type": [
+          "null",
+          "string"
+        ]
+      },
+      {
+        "default": "unknown",
+        "name": "source",
+        "type": [
+          "string",
+          "null"
+        ]
+      },
+      {
+        "name": "header",
+        "type": {
+          "fields": [
+            {
+              "default": null,
+              "name": "nohistory",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "default": null,
+              "name": "nomerge",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            },
+            {
+              "default": null,
+              "name": "job",
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            {
+              "default": null,
+              "name": "nonotifications",
+              "type": [
+                "boolean",
+                "null"
+              ]
+            }
+          ],
+          "name": "header",
+          "type": "record"
+        }
+      }
+    ],
+    "name": "AnalystValue",
+    "namespace": "eu.railnova.supernova.analyst",
+    "type": "record"
+  }

--- a/schemas/81.json
+++ b/schemas/81.json
@@ -1,0 +1,117 @@
+{
+  "fields": [
+    {
+      "name": "type",
+      "type": "string"
+    },
+    {
+      "name": "timestamp",
+      "type": "string"
+    },
+    {
+      "name": "asset",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "device",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "default": null,
+      "name": "asset_uic",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "is_open",
+      "type": "boolean"
+    },
+    {
+      "name": "content",
+      "type": "string"
+    },
+    {
+      "name": "version",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "recv_time",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "default": null,
+      "name": "processed_time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "default": "unknown",
+      "name": "source",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "header",
+      "type": {
+        "fields": [
+          {
+            "default": null,
+            "name": "nohistory",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          {
+            "default": null,
+            "name": "nomerge",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          },
+          {
+            "default": null,
+            "name": "job",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          {
+            "default": null,
+            "name": "nonotifications",
+            "type": [
+              "boolean",
+              "null"
+            ]
+          }
+        ],
+        "name": "header",
+        "namespace": "eu.railnova.supernova.analyst",
+        "type": "record"
+      }
+    }
+  ],
+  "name": "AnalystOutputSinkValue",
+  "namespace": "eu.railnova.supernova.analyst",
+  "type": "record"
+}

--- a/schemas/83.json
+++ b/schemas/83.json
@@ -1,0 +1,116 @@
+{
+  "fields": [
+    {
+      "name": "type",
+      "type": "string"
+    },
+    {
+      "name": "timestamp",
+      "type": "string"
+    },
+    {
+      "name": "asset",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "device",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "default": null,
+      "name": "asset_uic",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "name": "is_open",
+      "type": "boolean"
+    },
+    {
+      "name": "content",
+      "type": "string"
+    },
+    {
+      "name": "version",
+      "type": [
+        "int",
+        "null"
+      ]
+    },
+    {
+      "name": "recv_time",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "default": null,
+      "name": "processed_time",
+      "type": [
+        "null",
+        "string"
+      ]
+    },
+    {
+      "default": "unknown",
+      "name": "source",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    {
+      "name": "header",
+      "type": {
+        "fields": [
+          {
+            "default": null,
+            "name": "nohistory",
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          {
+            "default": null,
+            "name": "nomerge",
+            "type": [
+              "null",
+              "boolean"
+            ]
+          },
+          {
+            "default": null,
+            "name": "job",
+            "type": [
+              "null",
+              "string"
+            ]
+          },
+          {
+            "default": null,
+            "name": "nonotifications",
+            "type": [
+              "null",
+              "boolean"
+            ]
+          }
+        ],
+        "name": "header",
+        "type": "record"
+      }
+    }
+  ],
+  "name": "AnalystOutputSinkValue",
+  "namespace": "eu.railnova.supernova.analyst",
+  "type": "record"
+}


### PR DESCRIPTION
See issue #3

### Added

- A `railnova_kafka_mtls.py` program to access the Kafka broker using mTLS instead of SASL.
- A `railnova_kafka_nosr.py` program to access the Kafka broker using mTLS without Schema Registry.
- All the AVRO schemas required for Railnova's output sharing topics in a `schemas` folder.

### Changed

- The program `railnova_kafka_example.py`'s help now specify its use of SASL.
- The `README.md` has been updated to reflect changes above.
