### PR TITLE
Avoid dependency on `AvroDeserializer` and `SchemaRegistryClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-01-12
+
+### Changed
+
+- Use REST endpoint of Karapace to resolve AVRO schemas (see issue [#8](https://github.com/railnova/kafka-example/issues/8)).
+- Updated the `README.md` to account for added dependencies: `requests` and `types-confluent-kafka`.
+- Let sources pass `basic` type checking using Pylance.
+
 ## 2025-01-17
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Finally, install the required dependencies in the activated virtual environment:
 
 ```bash
 pip install confluent-kafka[avro,schemaregistry]==2.8.0
+pip install types-confluent-kafka
+pip install requests
 ```
 
 This will install version `2.8.0` of Confluent's client library with the optional support for AVRO

--- a/railnova_kafka_example.py
+++ b/railnova_kafka_example.py
@@ -2,6 +2,7 @@ import argparse
 import logging
 import os
 import sys
+import typing
 
 from confluent_kafka import Consumer, KafkaError
 from confluent_kafka.schema_registry import SchemaRegistryClient
@@ -40,7 +41,7 @@ def arguments() -> Arguments:
         default="railnova_kafka_example",
         help="Kafka consumer group id",
     )
-    return parser.parse_args()
+    return typing.cast(Arguments, parser.parse_args())
 
 
 def main() -> int:
@@ -102,14 +103,14 @@ def main() -> int:
             error: KafkaError | None = message.error()
             if error is None:
                 # log the deserialized message's key and value
-                k = avro_deserializer(message.key(), key_context)
-                v = avro_deserializer(message.value(), value_context)
+                k = avro_deserializer(message.key() or b"", key_context)
+                v = avro_deserializer(message.value() or b"", value_context)
                 logger.info(f"Received {k} -> {v}")
                 break
 
             else:
                 # Print the error message found in the message's value
-                logger.error(bytes.decode(message.value()))
+                logger.error(bytes.decode(message.value() or b"error message missing"))
         except KeyboardInterrupt:
             break
 


### PR DESCRIPTION
This PR shows how to avoid dependency on `AvroDeserializer` and `SchemaRegistryClient`.

- uses REST endpoint of Karapace to resolve AVRO schemas
- directly applies `fastavro` to parse schema and deserialize AVRO payloads

Incidentally it also pass basic type check (ie: Pylance in VSCode using `types-confluent-kafka`).

See issue #8